### PR TITLE
Release v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Trade on Bybit using natural language. Tell any AI assistant one sentence, and it can execute trades, check markets, manage positions, and more — zero installation required.
 
-**Version:** 1.3.0 | **License:** MIT
+**Version:** 1.4.1 | **License:** MIT
 
 ## How It Works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,9 +2,9 @@
 name: bybit-trading
 description: Bybit AI Trading Skill — Trade on Bybit using natural language. Covers spot, derivatives, earn, and more. Works with Claude, ChatGPT, OpenClaw, and any AI assistant.
 metadata:
-  version: 1.3.0  # Modular Architecture + Security Baseline
+  version: 1.4.1  # Modular Architecture + Security Baseline
   author: Bybit
-  updated: 2026-05-02
+  updated: 2026-05-28
 license: MIT
 ---
 
@@ -27,7 +27,7 @@ FOREGROUND (main agent — immediate):
 BACKGROUND (sub-agent — parallel):
 1. LOCAL_VERSION = metadata.version  (from YAML frontmatter above)
 2. SKILL_DIR = directory where this SKILL.md is located
-3. MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.3.0" https://api.bybit.com/skill/manifest
+3. MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.1" https://api.bybit.com/skill/manifest
    (returns JSON: {"version":"x.y.z", "files":{"SKILL.md":"sha256:...","modules/market.md":"sha256:...",...}})
 4. If fetch fails: return {status: "error", reason: "fetch_failed"}
 5. Path validation: For each file in manifest.files, reject the entire update if ANY path:
@@ -37,7 +37,7 @@ BACKGROUND (sub-agent — parallel):
 6. Version comparison (semver): split by ".", compare major → minor → patch numerically.
    If manifest.version > LOCAL_VERSION:
    a. For each file in manifest.files:
-      - Download: curl -sf -H "User-Agent: bybit-skill/1.3.0" https://raw.githubusercontent.com/bybit-exchange/skills/main/<file>
+      - Download: curl -sf -H "User-Agent: bybit-skill/1.4.1" https://raw.githubusercontent.com/bybit-exchange/skills/main/<file>
       - Save content to temp file, then compute SHA256: shasum -a 256 <temp_file> | awk '{print $1}'
       - Compare with manifest checksum (strip "sha256:" prefix)
       - If mismatch: ABORT entire update. return {status: "error", reason: "checksum_mismatch", file: "<file>"}
@@ -230,11 +230,11 @@ Tell the user what they can do. Examples:
 2. If the module has NOT been loaded in this session:
    a. Ensure manifest is available:
       - If cached from Auto Update: reuse it
-      - Otherwise: MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.3.0" https://api.bybit.com/skill/manifest
+      - Otherwise: MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.1" https://api.bybit.com/skill/manifest
       - If fetch fails: use current local version of the module (SKILL_DIR/modules/<module>.md)
         If no local version exists: inform user module unavailable, only GET operations permitted
       - Cache manifest in session
-   b. Download: curl -sf -H "User-Agent: bybit-skill/1.3.0" https://raw.githubusercontent.com/bybit-exchange/skills/main/modules/<module>.md
+   b. Download: curl -sf -H "User-Agent: bybit-skill/1.4.1" https://raw.githubusercontent.com/bybit-exchange/skills/main/modules/<module>.md
       - If download fails: use current local version of the module
         If no local version exists: inform user module unavailable, only GET operations permitted
    c. Verify integrity:
@@ -253,14 +253,14 @@ Tell the user what they can do. Examples:
 | price, ticker, kline, chart, orderbook, depth, funding rate, open interest, market data | **market** | `modules/market.md` | — |
 | buy, sell, spot, swap, exchange, convert, limit order, market order, cancel order, spot margin | **spot** | `modules/spot.md` | account |
 | long, short, leverage, futures, perpetual, close position, take profit, stop loss, trailing stop, conditional order, hedge mode, option, put, call, strike, expiry | **derivatives** | `modules/derivatives.md` | account |
-| earn, stake, redeem, yield, savings, flexible, fixed deposit, fixed term, fund pool, dual assets, structured product, discount buy, smart leverage, double win, liquidity mining, auto reinvest, early redeem | **earn** | `modules/earn.md` | account |
+| earn, stake, redeem, yield, savings, flexible, fixed deposit, fixed term, fund pool, dual assets, structured product, discount buy, smart leverage, double win, liquidity mining, auto reinvest, early redeem, hold-to-earn, airdrop yield, PWM, private wealth, investment plan, fund management, asset manager | **earn** | `modules/earn.md` | account |
 | balance, wallet, transfer, deposit, withdraw, fee, sub-account, API key, asset, fixed-rate borrow, borrow liability, repayment type, renew borrow, borrow market, borrow order, borrow contract, fixed borrow, margin borrow | **account** | `modules/account.md` | — |
 | websocket, stream, loan, borrow, repay, RFQ, block trade, spread, lending, broker, rate limit | **advanced** | `modules/advanced.md` | — |
 | P2P, peer to peer, advertisement, ad, OTC, fiat, fiat buy, fiat sell, convert fiat | **fiat** | `modules/fiat.md` | — |
 | copy trading, leader, follower, copy trade, leaderboard, recommend trader | **copy-trading** | `modules/copy-trading.md` | derivatives, account |
 | grid bot, DCA bot, martingale, combo bot, trading bot, create bot, close bot | **trading-bot** | `modules/trading-bot.md` | account, derivatives |
 | alpha, on-chain, DEX, meme coin, swap token, on-chain asset, token trade | **alpha-trade** | `modules/alpha-trade.md` | account |
-| TWAP, iceberg, chase order, chaseOrder, strategy order, split order, algorithmic | **strategy** | `modules/strategy.md` | account |
+| TWAP, iceberg, chase order, chaseOrder, strategy order, split order, algorithmic, POV, percentage of volume, volume participation | **strategy** | `modules/strategy.md` | account |
 | xStocks, tokenized stock, commodity perpetual, XAUUSDT, XAGUSDT, CLUSDT, crude oil, TradFi, metals agreement, oil agreement | **tradfi** | `modules/tradfi.md` | account, spot, derivatives |
 
 **Module-specific notes:**
@@ -269,14 +269,14 @@ Tell the user what they can do. Examples:
 - **Fiat/P2P**: P2P responses use `ret_code` (underscore format, not `retCode`). P2P ad posting requires General Advertiser+ permission level.
 - **Trading Bot**: Bot API uses `status_code`/`debug_msg` response format (NOT `retCode`/`retMsg`). **Always call `validate-input` (spot grid) or `validate` (futures grid) before creation** — this returns acceptable parameter ranges and catches errors early. DCA: max **5 trading pairs** per bot; if user requests more, ask them to choose up to 5.
 - **Alpha Trade**: Uses a **quote-then-execute** model — always call `/v5/alpha/trade/quote` first. Token codes use `CEX_<id>` (payment tokens like USDT) and `DEX_<id>` (on-chain tokens). All endpoints are POST (including queries). Settlement is on-chain (10-60s). KYC required.
-- **Strategy**: Strategy API uses `UTA_*` category format ONLY. Do NOT use `linear`/`spot` — map: `linear` → `UTA_USDT`, `spot` → `UTA_SPOT`, `inverse` → `UTA_INVERSE`. Chase orders: `chaseDistance` and `chasePercentE4` are **mutually exclusive** — use ONE only. **NEVER use `category=linear` or `category=spot` in Strategy API calls** — this will cause errors. Always translate: derivatives/perpetual/futures → `UTA_USDT`, spot → `UTA_SPOT`.
+- **Strategy**: Strategy API uses `UTA_*` category format ONLY. Do NOT use `linear`/`spot` — map: `linear` → `UTA_USDT`, `spot` → `UTA_SPOT`, `inverse` → `UTA_INVERSE`. Chase orders: `chaseDistance` and `chasePercentE4` are **mutually exclusive** — use ONE only. **NEVER use `category=linear` or `category=spot` in Strategy API calls** — this will cause errors. Always translate: derivatives/perpetual/futures → `UTA_USDT`, spot → `UTA_SPOT`. **POV** (Percentage of Volume): adapts child order size to live market activity; only supports Perp (NOT spot).
 - **Copy Trading**: The `investmentE8` parameter uses **8-decimal precision** (multiply USDT amount by 10^8). For example, 100 USDT = `10000000000` (100 × 10^8). Always apply this conversion when the user specifies an investment amount in USDT.
 - **TradFi**: Discover instruments via `instruments-info` with `symbolType=xstocks` (spot, e.g., `TSLAXUSDT`) or `symbolType=commodity` (linear, e.g., `XAUUSDT`/`CLUSDT`). Trading reuses standard V5 order endpoints — no TradFi-specific trade API. **Metals (XAU/XAG) and Crude Oil (CL) require a one-time master-account agreement** via `POST /v5/user/agreement` (`categoryV2=2` metals, `categoryV2=3` oil); xStocks do not. Subaccounts inherit eligibility once the master signs. xStocks instruments include extra fields such as `xstockMultiplier`.
 
 ### Routing Notes
 
 - Keywords are **hints, not strict rules** — always use semantic understanding of the user's full request to determine the correct module(s). When ambiguous (e.g., "borrow" could mean spot margin or advanced lending), prefer the module matching the broader conversation context, or ask the user to clarify.
-- Common Chinese synonyms: 查价/看价 → market, 买/卖/现货 → spot, 开多/开空/合约/杠杆 → derivatives, 理财/质押/双币 → earn, 余额/转账/充值/提币 → account, 跟单 → copy-trading, 网格/DCA → trading-bot, 链上/meme/DEX/代币 → alpha-trade, 代币化股票/特斯拉/苹果/英伟达/黄金/白银/原油/商品永续 → tradfi
+- Common Chinese synonyms: 查价/看价 → market, 买/卖/现货 → spot, 开多/开空/合约/杠杆 → derivatives, 理财/质押/双币/持币生息/私人财富 → earn, 余额/转账/充值/提币 → account, 跟单 → copy-trading, 网格/DCA → trading-bot, 链上/meme/DEX/代币 → alpha-trade, 代币化股票/特斯拉/苹果/英伟达/黄金/白银/原油/商品永续 → tradfi, 拆单/算法单/POV → strategy
 
 ### Loading Rules
 
@@ -318,7 +318,7 @@ All failure scenarios (auto-update, module loading, manifest fetch) follow this 
 | `X-BAPI-RECV-WINDOW` | `5000` |
 | `X-BAPI-SIGN-TYPE` | `2` for RSA-SHA256; omit or set `1` for HMAC-SHA256 |
 | `Content-Type` | `application/json` (POST) |
-| `User-Agent` | `bybit-skill/1.3.0` |
+| `User-Agent` | `bybit-skill/1.4.1` |
 | `X-Referer` | `bybit-skill` |
 
 ### Signing Algorithm
@@ -376,7 +376,7 @@ curl -s "${BASE_URL}/v5/position/list?${QUERY}" \
   -H "X-BAPI-TIMESTAMP: ${TIMESTAMP}" \
   -H "X-BAPI-SIGN: ${SIGN}" \
   -H "X-BAPI-RECV-WINDOW: ${RECV_WINDOW}" \
-  -H "User-Agent: bybit-skill/1.3.0" \
+  -H "User-Agent: bybit-skill/1.4.1" \
   -H "X-Referer: bybit-skill"
 ```
 
@@ -398,7 +398,7 @@ curl -s -X POST "${BASE_URL}/v5/order/create" \
   -H "X-BAPI-TIMESTAMP: ${TIMESTAMP}" \
   -H "X-BAPI-SIGN: ${SIGN}" \
   -H "X-BAPI-RECV-WINDOW: ${RECV_WINDOW}" \
-  -H "User-Agent: bybit-skill/1.3.0" \
+  -H "User-Agent: bybit-skill/1.4.1" \
   -H "X-Referer: bybit-skill" \
   -d "${BODY}"
 ```

--- a/modules/account.md
+++ b/modules/account.md
@@ -149,7 +149,8 @@ POST /v5/account/repay
 | Sub-account List | `/v5/user/query-sub-members` | GET | — | — | — |
 | API Key Info | `/v5/user/query-api` | GET | — | — | — |
 | Member Type | `/v5/user/get-member-type` | GET | — | — | — |
-| Affiliate User Info | `/v5/user/aff-customer-info` | GET | uid | — | — |
+| Affiliate User Info | `/v5/user/aff-customer-info` | GET | uid | coin, business | — |
+| Affiliate Sub List | `/v5/affiliate/affiliate-sub-list` | GET | — | cursor, size, startDate, endDate, subAffId | — |
 | Sub-account List (full) | `/v5/user/submembers` | GET | — | pageSize, nextCursor | — |
 | Sub-account All Keys | `/v5/user/sub-apikeys` | GET | subMemberId | limit, cursor | — |
 | Escrow Sub-accounts | `/v5/user/escrow_sub_members` | GET | — | pageSize, nextCursor | — |
@@ -239,9 +240,21 @@ POST /v5/account/repay
 - `currency` (required): Coin name (e.g. `USDT`). Unified account only.
 - Note: Path uses capital `L` in `Liability` (per BGW routing).
 
+### Wallet Balance (`/v5/account/wallet-balance`)
+- Response coin-level field `colRes` (platform-level collateral restriction): `-1` not applicable, `0` normal, `1` restricted (reaching platform limit), `2` fully restricted (at platform limit).
+- Error `182011` on Set Collateral Switch: "The {coins} collateral amount has reached the platform limit."
+
+### Affiliate User Info (`/v5/user/aff-customer-info`)
+- `business` filter: `1` Derivatives, `2` Spot, `3` ByFi, `4` USDC, `5` Options.
+- Response includes 30-day and 365-day volumes, deposit amounts, VIP level, KYC level, TradFi volume, and commission breakdown by coin.
+
+### Affiliate Sub List (`/v5/affiliate/affiliate-sub-list`)
+- Query sub-affiliates with optional commission date range (`startDate`/`endDate` in YYYY-MM-DD format).
+- `size`: 0–100 (0 = all, up to 100). Rate limit: 10 req/s. Requires Master UID with affiliate permission.
+
 ### API Key Permissions
-- 15 permission categories: ContractTrade, Spot, Wallet, Options, Derivatives, CopyTrading, BlockTrade, Exchange, NFT, Affiliate, Earn, FiatP2P, FiatBitPay, FiatBybitPay (deprecated), FiatConvertBroker.
-- Read-Write API keys cannot add or delete FiatP2P, FiatBitPay (formerly FiatBybitPay), and FiatConvertBroker permissions.
+- 14 permission categories: ContractTrade, Spot, Wallet, Options, Derivatives, CopyTrading, BlockTrade, Exchange, NFT, Affiliate, Earn, FiatP2P, FiatBitPay, FiatConvertBroker.
+- Read-Write API keys cannot add or delete FiatP2P, FiatBitPay, and FiatConvertBroker permissions.
 
 ## Enums
 

--- a/modules/advanced.md
+++ b/modules/advanced.md
@@ -79,7 +79,12 @@ Auth: `{"op": "auth", "args": ["<apiKey>", "<expires>", "<signature>"]}`
 | Supply Contract Info | `/v5/crypto-loan-fixed/supply-contract-info` | GET | supplyCurrency | — |
 | Supply Order Quote | `/v5/crypto-loan-fixed/supply-order-quote` | GET | orderCurrency | orderBy |
 | Supply Order Info | `/v5/crypto-loan-fixed/supply-order-info` | GET | — | orderId |
-| Cancel Supply | `/v5/crypto-loan-fixed/supply-order-cancel` | POST | orderId | — |
+| Place Supply | `/v5/crypto-loan-fixed/supply` | POST | orderCurrency, orderAmount, annualRate, term | availableSource |
+| Cancel Supply | `/v5/crypto-loan-fixed/supply-order-cancel` | POST | orderId | refundedAccount |
+
+> **Place Supply `availableSource`**: `0` funding account (default), `1` flexible savings, `2` mixed (funding + flexible savings).
+> **Cancel Supply `refundedAccount`** (only effective when order was placed from flexible savings): `0` redeem to funding account (default), `1` keep in flexible savings (unfreeze).
+> **Error `148048`**: "The collateral amount has exceeded the platform limit" — applies to borrow, renew, and adjust-LTV operations.
 
 ### Crypto Loan — Flexible (authentication required)
 
@@ -88,8 +93,8 @@ Auth: `{"op": "auth", "args": ["<apiKey>", "<expires>", "<signature>"]}`
 | Repay | `/v5/crypto-loan-flexible/repay` | POST | loanCoin, repayAmount | — |
 | Repay Collateral | `/v5/crypto-loan-flexible/repay-collateral` | POST | orderId | — |
 | Ongoing Coins | `/v5/crypto-loan-flexible/ongoing-coin` | GET | — | loanCurrency |
-| Borrow History | `/v5/crypto-loan-flexible/borrow-history` | GET | — | limit |
-| Repayment History | `/v5/crypto-loan-flexible/repayment-history` | GET | — | loanCurrency |
+| Borrow History | `/v5/crypto-loan-flexible/borrow-history` | GET | — | orderId, loanCurrency, limit, cursor |
+| Repayment History | `/v5/crypto-loan-flexible/repayment-history` | GET | — | repayId, loanCurrency, limit, cursor |
 
 ---
 
@@ -98,13 +103,18 @@ Auth: `{"op": "auth", "args": ["<apiKey>", "<expires>", "<signature>"]}`
 | Endpoint | Path | Method | Required Params | Optional Params |
 |----------|------|--------|----------------|-----------------|
 | Product Info | `/v5/ins-loan/product-infos` | GET | — | productId |
-| Margin Coin Conversion | `/v5/ins-loan/ensure-tokens-convert` | GET | — | loanOrderId |
+| Margin Coin Conversion | `/v5/ins-loan/ensure-tokens-convert` | GET | — | productId |
+| Margin Coin Info | `/v5/ins-loan/ensure-tokens` | GET | — | productId |
 | Loan Order | `/v5/ins-loan/loan-order` | GET | — | orderId, startTime, endTime, limit |
 | Repayment History | `/v5/ins-loan/repaid-history` | GET | — | startTime, endTime, limit |
 | LTV Conversion | `/v5/ins-loan/ltv-convert` | GET | — | — |
-| Margin Coin Info | `/v5/ins-loan/ensure-tokens` | GET | — | productId |
-| LTV | `/v5/ins-loan/ltv` | GET | — | — |
-| Repay | `/v5/ins-loan/repay-loan` | POST | — | — |
+| Coin Delta Amount | `/v5/ins-loan/coin-delta-amount` | GET | — | coin |
+| Association UID | `/v5/ins-loan/association-uid` | POST | uid, operate | — |
+| Repay | `/v5/ins-loan/repay-loan` | POST | token, quantity | — |
+
+> **Association UID `operate`**: `0` = bind UID, `1` = unbind UID. Rate limit: 1 req/s.
+> **Coin Delta Amount**: Returns per-coin delta hedging limits (`coinDeltaSize`, `coinDeltaAvailableAmount`) and aggregate `riskUnitDeltaAmount`.
+> **Product Info `productType`**: `0` = Default, `1` = CTA, `2` = Hedge.
 
 ---
 

--- a/modules/derivatives.md
+++ b/modules/derivatives.md
@@ -132,12 +132,14 @@ POST /v5/position/trading-stop
 
 | Endpoint | Path | Method | Required Params | Optional Params | Rate Limit | Categories |
 |----------|------|--------|----------------|-----------------|------------|------------|
-| Place Order | `/v5/order/create` | POST | category, symbol, side, orderType, qty | price, timeInForce, orderLinkId, triggerPrice, takeProfit, stopLoss, tpslMode, reduceOnly, positionIdx, marketUnit... | 10-20/s | spot, linear, inverse, option |
+| Place Order | `/v5/order/create` | POST | category, symbol, side, orderType, qty | price, timeInForce, orderLinkId, triggerPrice, takeProfit, stopLoss, tpslMode, reduceOnly, positionIdx, marketUnit, rpiTakerAccess... | 10-20/s | spot, linear, inverse, option |
 | Amend Order | `/v5/order/amend` | POST | category, symbol | orderId/orderLinkId, qty, price, takeProfit, stopLoss, triggerPrice | 10/s | spot, linear, inverse, option |
 | Cancel Order | `/v5/order/cancel` | POST | category, symbol | orderId/orderLinkId, orderFilter | 10-20/s | spot, linear, inverse, option |
 | Get Open Orders | `/v5/order/realtime` | GET | category | symbol, baseCoin, orderId, orderLinkId, openOnly, limit, cursor | 50/s | spot, linear, inverse, option |
 | Cancel All Orders | `/v5/order/cancel-all` | POST | category | symbol, baseCoin, settleCoin, orderFilter, stopOrderType | 10/s | spot, linear, inverse, option |
 | Order History | `/v5/order/history` | GET | category | symbol, orderId, orderLinkId, orderFilter, orderStatus, startTime, endTime, limit, cursor | 50/s | spot, linear, inverse, option |
+
+> **`rpiTakerAccess`** (Place Order, optional boolean, default `false`): When `true`, allows this order to be filled against RPI (Retail Price Improvement) orders. Response field `rpiMatchedQty` in Order History shows cumulative RPI-matched quantity.
 | Batch Place Order | `/v5/order/create-batch` | POST | category, request[] | — | per-order | spot, linear, inverse, option |
 | Batch Amend Order | `/v5/order/amend-batch` | POST | category, request[] | — | per-order | spot, linear, inverse, option |
 | Batch Cancel Order | `/v5/order/cancel-batch` | POST | category, request[] | — | per-order | spot, linear, inverse, option |

--- a/modules/earn.md
+++ b/modules/earn.md
@@ -9,6 +9,8 @@
 3. [Advance Earn](#scenario-advance-earn) — Dual Assets / Smart Leverage / DoubleWin / Discount Buy
 4. [Liquidity Mining](#scenario-liquidity-mining) — Pool liquidity provision
 5. [BYUSDT Token](#scenario-byusdt-token) — Mint / Redeem earn token
+6. [Hold-to-Earn](#scenario-hold-to-earn) — Airdrop yield by holding coins
+7. [PWM (Private Wealth Management)](#scenario-pwm) — Institutional fund management & user investment plans
 
 ---
 
@@ -387,3 +389,75 @@ GET /v5/earn/token/history-apr?coin=BYUSDT&range=2
 | Yield History | `/v5/earn/token/yield` | GET | Yes | coin | startTime, endTime, limit, cursor |
 | Hourly Yield | `/v5/earn/token/hourly-yield` | GET | Yes | coin | startTime, endTime, limit, cursor |
 | APR History | `/v5/earn/token/history-apr` | GET | No | coin, range | — |
+
+---
+
+## Scenario: Hold-to-Earn
+
+User might say: "hold to earn", "airdrop yield", "holding rewards", "USDE yield"
+
+> Earn yield by holding eligible coins (USDE, USD1) — no staking needed, yield distributed daily as airdrops.
+
+| Endpoint | Path | Method | Auth | Required | Optional |
+|----------|------|--------|------|----------|----------|
+| Product List | `/v5/earn/hold-to-earn/product` | GET | No | — | — |
+| Yield History | `/v5/earn/hold-to-earn/yield-history` | GET | Yes | limit (1-49) | timeStart, timeEnd, cursor |
+
+> **Notes**:
+> - Product status: `NotStarted`, `Online`, `Ended`. Only `Online` products distribute yield.
+> - `timeStart`/`timeEnd` are Unix seconds, cannot query >3 months ago.
+> - Response: `effectiveAmount` (principal), `pnl` (yield distributed), `apy` (annualized rate).
+
+---
+
+## Scenario: PWM
+
+User might say: "private wealth", "PWM", "investment plan", "fund management", "asset manager", "subscribe plan", "redeem plan"
+
+> Private Wealth Management — institutional fund management and user investment plans.
+
+### PWM — User Side
+
+| Endpoint | Path | Method | Auth | Required | Optional |
+|----------|------|--------|------|----------|----------|
+| List Plans | `/v5/earn/pwm/investment-plan/all` | GET | Yes | — | planId, status, limit, cursor |
+| Plan Detail | `/v5/earn/pwm/investment-plan/detail` | GET | Yes | planId | — |
+| New Plan Detail | `/v5/earn/pwm/investment-plan/new-plan` | GET | Yes | planId | — |
+| Subscribe | `/v5/earn/pwm/investment-plan/subscribe` | POST | Yes | planId, orderLinkId | accountType |
+| Invest More | `/v5/earn/pwm/investment-plan/invest-more` | POST | Yes | planId, category, productId, amount, orderLinkId | accountType |
+| Redeem | `/v5/earn/pwm/investment-plan/redeem` | POST | Yes | planId, category, productId, orderLinkId | amount, shares, positionId |
+| Claim | `/v5/earn/pwm/investment-plan/claim` | POST | Yes | planId, orderLinkId | toAccountType |
+| Asset Trend | `/v5/earn/pwm/investment-plan/asset-trend` | GET | Yes | planId | startTime, endTime |
+| Fund NAV | `/v5/earn/pwm/investment-plan/fund-nav` | GET | Yes | fundId | startTime, endTime |
+| Order List | `/v5/earn/pwm/investment-plan/order` | GET | Yes | — | planId, category, type, status, startTime, endTime, limit, cursor, orderLinkId |
+| Product Cards | `/v5/earn/pwm/customize-plan/product` | GET | No | — | — |
+| Create Custom Plan | `/v5/earn/pwm/customize-plan/create` | POST | Yes | products[], orderLinkId | accountType |
+
+> **Notes**:
+> - Plan status lifecycle: `PendingSubscription` → `Active` → `Closed`.
+> - `category` values: `multiCoinEarning`, `fixedYield`, `equityFund`, `onchainEarn`.
+> - `accountType`: `FUND` (default), `UNIFIED`.
+> - Redeem uses `shares` for `equityFund` category, `amount` for others.
+
+### PWM — Institutional Side
+
+| Endpoint | Path | Method | Auth | Required | Optional |
+|----------|------|--------|------|----------|----------|
+| List Funds | `/v5/earn/pwm/asset-manager/all-funds` | GET | Yes | — | — |
+| Create Fund | `/v5/earn/pwm/asset-manager/create-fund` | POST | Yes | fundName, coin, profitShareRate, managementFeeRate, reqLinkId | — |
+| Settle Profit | `/v5/earn/pwm/asset-manager/settle-profit` | POST | Yes | fundId, reqLinkId | — |
+| Create Investment Plan | `/v5/earn/pwm/asset-manager/create-investment-plan` | POST | Yes | accountUid, planName, planType, investmentDistribution[], reqLinkId | — |
+| Get Plans | `/v5/earn/pwm/asset-manager/get-investment-plan` | GET | Yes | — | — |
+| Manage Plan | `/v5/earn/pwm/asset-manager/manage-investment-plan` | POST | Yes | planId, reqLinkId | updateStatus, updateFunds[] |
+| List Orders | `/v5/earn/pwm/asset-manager/all-order` | GET | Yes | — | — |
+| Manage Order | `/v5/earn/pwm/asset-manager/manage-order` | POST | Yes | orderId, action, reqLinkId | — |
+| Create Sub-Account | `/v5/earn/pwm/asset-manager/create-sub-account` | POST | Yes | fundId, reqLinkId | — |
+| Fund Transfer | `/v5/earn/pwm/fund-transfer` | POST | Yes | transferId, fromUserId, toUserId, amount, coin | — |
+| Transfer Records | `/v5/earn/pwm/query-fund-transfer-result` | GET | Yes | — | transferId, fromUserId |
+
+> **Notes**:
+> - Fund status lifecycle: `PendingSubscribe` → `Active` → `Closing` → `Closed`.
+> - Supported `coin`: BTC, ETH, USDT, USDC, SOL, MNT, XRP.
+> - `action` values: `Approve`, `Reject`.
+> - `planType`: `stable`, `advanced`.
+> - `reqLinkId` max 36 chars, used for idempotency.

--- a/modules/strategy.md
+++ b/modules/strategy.md
@@ -118,14 +118,57 @@ POST /v5/strategy/create
 {"category":"UTA_USDT","symbol":"BTCUSDT","side":"Buy","size":"1","strategyType":"chaseOrder","chasePercentE4":50,"maxChasePrice":"90000"}
 ```
 
+### POV (Percentage of Volume)
+
+Adapts child order size to live market activity — execution rate scales with real-time volume.
+
+> ⚠️ **POV only supports Perp**: `UTA_USDT`, `UTA_USDC`, `UTA_INVERSE`. NOT `UTA_SPOT`.
+
+**Required**: category, symbol, side, strategyType(`pov`), povParams
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| category | string | Y | `UTA_USDT`, `UTA_USDC`, `UTA_INVERSE` only |
+| symbol | string | Y | e.g. `BTCUSDT` |
+| side | string | Y | `Buy` or `Sell` |
+| strategyType | string | Y | `pov` |
+| size | string | N | Max quantity (maxQty). Required when interval>0 unless duration is set |
+| duration | integer | N | Total time in seconds. Range: [900, 86400]. Required when interval>0 unless size is set |
+| interval | integer | N | Seconds between orders. 0=OneTime mode (single child order then stop). Range: 0 or [5, 3600] |
+| reduceOnly | boolean | N | Only reduce position. Default: false |
+| positionIdx | integer | N | 0=one-way, 1=hedge-long, 2=hedge-short. Default: 0 |
+| povParams | object | Y | POV-specific parameters (see below) |
+
+**povParams object**:
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| mode | string | Y | `TradedVolume`, `OppositeSideLiquidity`, or `SameSideLiquidity` |
+| participationRate | string | Y | Percentage `"1"`-`"100"`, max 1 decimal place |
+| referenceWindow | string | Conditional | Seconds `"60"`-`"14400"`. Required when mode=`TradedVolume` |
+| depthReference | integer | Conditional | Orderbook depth level 1-10. Required when mode=`OppositeSideLiquidity` or `SameSideLiquidity` |
+
+**Execution logic by mode**:
+- `TradedVolume` → Market order (childQty = volume in referenceWindow × participationRate%)
+- `OppositeSideLiquidity` → Taker Limit order @BBO (childQty = opposite side depth × participationRate%)
+- `SameSideLiquidity` → Post-Only order @BBO (childQty = same side depth × participationRate%)
+
+> **interval=0 (OneTime)**: Places a single child order then stops immediately. No size/duration needed.
+> **interval>0**: At least one of `size` or `duration` must be set as a stop condition.
+
+```
+POST /v5/strategy/create
+{"category":"UTA_USDT","symbol":"BTCUSDT","side":"Buy","strategyType":"pov","size":"10","duration":3600,"interval":30,"povParams":{"mode":"TradedVolume","participationRate":"5","referenceWindow":"300"}}
+```
+
 ---
 
 ## Query, Monitor & Stop
 
 | Endpoint | Path | Method | Key Params |
 |----------|------|--------|-----------|
-| Strategy List | `/v5/strategy/list` | GET | strategyId, symbol, category(`UTA_*`), strategyType, status, beginTimeE0, endTimeE0, pageSize(max 50), cursor |
-| Strategy Orders | `/v5/strategy/order-list` | GET | strategyId(**required**), status, symbol, BeginTimeE0, EndTimeE0, pageSize(max 50), cursor, StrategyType |
+| Strategy List | `/v5/strategy/list` | GET | strategyId, symbol, category(`UTA_*`), strategyType(`twap`/`iceberg`/`chaseOrder`/`pov`), status, beginTimeE0, endTimeE0, pageSize(max 50), cursor |
+| Strategy Orders | `/v5/strategy/order-list` | GET | strategyId(**required**), status, symbol, BeginTimeE0, EndTimeE0, pageSize(max 50), cursor, StrategyType(`twap`/`iceberg`/`chaseOrder`/`pov`) |
 | Stop Strategy | `/v5/strategy/stop` | POST | strategyId(**required**) |
 
 ### Strategy Status Codes
@@ -143,13 +186,20 @@ POST /v5/strategy/create
 |------|--------|
 | 0 | Not terminated |
 | 1 | User manually stopped |
-| 2 | Completed normally |
-| 3 | Trading failed |
+| 2 | Completed normally (all quantity filled) |
+| 3 | Insufficient balance |
 | 4 | Position closed |
 | 5 | Risk control triggered |
 | 6 | System error |
 | 7 | Exceeded maxChasePrice |
 | 8 | Hit limit price protection |
+| 18 | Beyond maxChasePrice |
+| 24 | TWAP hit limit price |
+| 27 | POV maxDuration reached |
+| 28 | POV maxQty reached |
+| 29 | POV trading failed 6 consecutive times |
+| 30 | POV OneTime mode executed |
+| 31 | POV no fills in 24 hours |
 
 ### Order Status (for order-list)
 
@@ -186,6 +236,21 @@ Strategy endpoints use the **standard V5 response format** (`retCode`/`retMsg`):
 
 ---
 
+## POV Error Codes
+
+| Code | Description |
+|------|-------------|
+| 60088 | Invalid mode |
+| 60089 | participationRate out of range [1,100] or more than 1 decimal place |
+| 60090 | referenceWindow or depthReference missing or invalid for selected mode |
+| 60091 | Missing stop condition (size or duration) when interval>0 |
+| 60092 | Estimated child qty out of [minQty, maxOrderQty] |
+| 60093 | duration out of range [900, 86400] |
+| 60094 | Estimated child qty exceeds maxQty |
+| 60095 | interval exceeds duration |
+
+---
+
 ## Notes
 
 - `strategyId` is a UUID returned from the create response -- store it for query/stop calls
@@ -196,4 +261,5 @@ Strategy endpoints use the **standard V5 response format** (`retCode`/`retMsg`):
 - Chase: strategyType is `chaseOrder` (camelCase, NOT `chase`); generates frequent order cancellations/replacements (watch rate limits)
 - Chase: many cancelled orders (status=4) is NORMAL behavior -- it cancels and replaces to track price
 - chasePercentE4 and chaseDistance are mutually exclusive across all strategy types
-- All size/price params are strings; duration/interval/chasePercentE4/orderCount are integers
+- POV: only supports Perp (UTA_USDT/UTA_USDC/UTA_INVERSE), NOT spot; interval=0 is OneTime mode
+- All size/price params are strings; duration/interval/chasePercentE4/orderCount/depthReference are integers


### PR DESCRIPTION
## v1.4.1 (2026-05-28)

### New
- **strategy**: POV (Percentage of Volume) strategy — 3 modes, error codes 60088–60095
- **earn**: Hold-to-Earn + PWM (23 endpoints)
- **advanced**: Fixed Loan Place Supply, Institutional Loan new endpoints
- **account**: Affiliate Sub List, colRes field
- **derivatives**: rpiTakerAccess / rpiMatchedQty

### Changed
- Fixed Loan Cancel Supply `refundedAccount` param
- API Key permissions 15→14 (removed FiatBybitPay)
- Flexible Loan History params expanded

### Spec
- `.spec-commit`: 25d51c3 → 1639d93