### PR TITLE
Release v1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Trade on Bybit using natural language. Tell any AI assistant one sentence, and it can execute trades, check markets, manage positions, and more — zero installation required.
 
-**Version:** 1.4.2 | **License:** MIT
+**Version:** 1.4.3 | **License:** MIT
 
 ## How It Works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,9 +2,9 @@
 name: bybit-trading
 description: Bybit AI Trading Skill — Trade on Bybit using natural language. Covers spot, derivatives, earn, and more. Works with Claude, ChatGPT, OpenClaw, and any AI assistant.
 metadata:
-  version: 1.4.2  # Modular Architecture + Security Baseline
+  version: 1.4.3  # Modular Architecture + Security Baseline
   author: Bybit
-  updated: 2026-06-04
+  updated: 2026-06-17
 license: MIT
 ---
 
@@ -27,7 +27,7 @@ FOREGROUND (main agent — immediate):
 BACKGROUND (sub-agent — parallel):
 1. LOCAL_VERSION = metadata.version  (from YAML frontmatter above)
 2. SKILL_DIR = directory where this SKILL.md is located
-3. MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.2" https://api.bybit.com/skill/manifest
+3. MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.3" https://api.bybit.com/skill/manifest
    (returns JSON: {"version":"x.y.z", "files":{"SKILL.md":"sha256:...","modules/market.md":"sha256:...",...}})
 4. If fetch fails: return {status: "error", reason: "fetch_failed"}
 5. Path validation: For each file in manifest.files, reject the entire update if ANY path:
@@ -37,7 +37,7 @@ BACKGROUND (sub-agent — parallel):
 6. Version comparison (semver): split by ".", compare major → minor → patch numerically.
    If manifest.version > LOCAL_VERSION:
    a. For each file in manifest.files:
-      - Download: curl -sf -H "User-Agent: bybit-skill/1.4.2" https://raw.githubusercontent.com/bybit-exchange/skills/main/<file>
+      - Download: curl -sf -H "User-Agent: bybit-skill/1.4.3" https://raw.githubusercontent.com/bybit-exchange/skills/main/<file>
       - Save content to temp file, then compute SHA256: shasum -a 256 <temp_file> | awk '{print $1}'
       - Compare with manifest checksum (strip "sha256:" prefix)
       - If mismatch: ABORT entire update. return {status: "error", reason: "checksum_mismatch", file: "<file>"}
@@ -230,11 +230,11 @@ Tell the user what they can do. Examples:
 2. If the module has NOT been loaded in this session:
    a. Ensure manifest is available:
       - If cached from Auto Update: reuse it
-      - Otherwise: MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.2" https://api.bybit.com/skill/manifest
+      - Otherwise: MANIFEST = curl -sf -H "User-Agent: bybit-skill/1.4.3" https://api.bybit.com/skill/manifest
       - If fetch fails: use current local version of the module (SKILL_DIR/modules/<module>.md)
         If no local version exists: inform user module unavailable, only GET operations permitted
       - Cache manifest in session
-   b. Download: curl -sf -H "User-Agent: bybit-skill/1.4.2" https://raw.githubusercontent.com/bybit-exchange/skills/main/modules/<module>.md
+   b. Download: curl -sf -H "User-Agent: bybit-skill/1.4.3" https://raw.githubusercontent.com/bybit-exchange/skills/main/modules/<module>.md
       - If download fails: use current local version of the module
         If no local version exists: inform user module unavailable, only GET operations permitted
    c. Verify integrity:
@@ -319,7 +319,7 @@ All failure scenarios (auto-update, module loading, manifest fetch) follow this 
 | `X-BAPI-RECV-WINDOW` | `5000` |
 | `X-BAPI-SIGN-TYPE` | `2` for RSA-SHA256; omit or set `1` for HMAC-SHA256 |
 | `Content-Type` | `application/json` (POST) |
-| `User-Agent` | `bybit-skill/1.4.2` |
+| `User-Agent` | `bybit-skill/1.4.3` |
 | `X-Referer` | `bybit-skill` |
 
 ### Signing Algorithm
@@ -377,7 +377,7 @@ curl -s "${BASE_URL}/v5/position/list?${QUERY}" \
   -H "X-BAPI-TIMESTAMP: ${TIMESTAMP}" \
   -H "X-BAPI-SIGN: ${SIGN}" \
   -H "X-BAPI-RECV-WINDOW: ${RECV_WINDOW}" \
-  -H "User-Agent: bybit-skill/1.4.2" \
+  -H "User-Agent: bybit-skill/1.4.3" \
   -H "X-Referer: bybit-skill"
 ```
 
@@ -399,7 +399,7 @@ curl -s -X POST "${BASE_URL}/v5/order/create" \
   -H "X-BAPI-TIMESTAMP: ${TIMESTAMP}" \
   -H "X-BAPI-SIGN: ${SIGN}" \
   -H "X-BAPI-RECV-WINDOW: ${RECV_WINDOW}" \
-  -H "User-Agent: bybit-skill/1.4.2" \
+  -H "User-Agent: bybit-skill/1.4.3" \
   -H "X-Referer: bybit-skill" \
   -d "${BODY}"
 ```

--- a/modules/account.md
+++ b/modules/account.md
@@ -252,6 +252,9 @@ POST /v5/account/repay
 - Query sub-affiliates with optional commission date range (`startDate`/`endDate` in YYYY-MM-DD format).
 - `size`: 0–100 (0 = all, up to 100). Rate limit: 10 req/s. Requires Master UID with affiliate permission.
 
+### Set Margin Mode (`/v5/account/set-margin-mode`)
+- Error code `3200425`: Cannot switch to Portfolio Margin (PM) mode while holding an Event Futures position. Close the position before switching.
+
 ### API Key Permissions
 - 14 permission categories: ContractTrade, Spot, Wallet, Options, Derivatives, CopyTrading, BlockTrade, Exchange, NFT, Affiliate, Earn, FiatP2P, FiatBitPay, FiatConvertBroker.
 - Read-Write API keys cannot add or delete FiatP2P, FiatBitPay, and FiatConvertBroker permissions.

--- a/modules/alpha-trade.md
+++ b/modules/alpha-trade.md
@@ -209,6 +209,99 @@ Rate limit: 3/s (UID), 2000/s global.
 
 ---
 
+## Scenario: Alpha LP / Farm (Liquidity Pools)
+
+User might say: "stake to LP pool", "add liquidity to ETH-USDC pool", "redeem LP position", "withdraw from pool", "view LP positions", "LP order history"
+
+> Provide liquidity to Alpha on-chain pools, earn rewards. Same token-code convention (`CEX_<id>` payment, `DEX_<id>` token). All endpoints **POST**. KYC required, write-permission API key. Stake/redeem are async — 200 response is ACK only; poll `position-list` or `order-list` to confirm. On-chain confirmation typically 10-60s.
+
+**⚠️ Mandatory Stake flow**
+
+> 1. `POST /v5/alpha/lp/pool-list` → discover pools (filter by `tokenSymbol`)
+> 2. `POST /v5/alpha/lp/pool-info` → get full pool details (APY, fee rate, reserves, price range)
+> 3. `POST /v5/alpha/lp/pay-token-list` → verify available balance, get `tokenCode`
+> 4. **Confirm with user**: pool, stake amount, range, expected APY
+> 5. `POST /v5/alpha/lp/stake` → returns `positionId` + `orderNo`
+> 6. Poll `POST /v5/alpha/lp/position-list` and `/order-list` until `orderStatus=2` (Success)
+
+**⚠️ Mandatory Redeem flow**
+
+> 1. `POST /v5/alpha/lp/position-list` → get `positionId` and current value
+> 2. **Confirm with user**: position, reduction ratio (`dercRatio`)
+> 3. `POST /v5/alpha/lp/redeem` → returns `orderNo`
+> 4. Poll `/order-list` until `orderStatus=2` (Success)
+
+### Pool Discovery
+
+```
+POST /v5/alpha/lp/pool-list  {"tokenSymbol":"ETH"}
+POST /v5/alpha/lp/pool-info  {"poolAddress":"0x..."}
+POST /v5/alpha/lp/pay-token-list  {}
+POST /v5/alpha/lp/pay-token-price  {"tokenCode":["CEX_1","CEX_2"],"chainCode":"ETH"}
+```
+
+| Endpoint | Path | Method | Required | Optional |
+|----------|------|--------|----------|----------|
+| Pool List | `/v5/alpha/lp/pool-list` | POST | — | tokenSymbol |
+| Pool Info | `/v5/alpha/lp/pool-info` | POST | poolAddress | — |
+| Pay Token List | `/v5/alpha/lp/pay-token-list` | POST | — | chainCode, tokenAddress |
+| Pay Token Price | `/v5/alpha/lp/pay-token-price` | POST | tokenCode | chainCode |
+
+> `pay-token-price`: `tokenCode` is an array (1–50 tokens) for batch query. `pay-token-list`: returns user's `availableBalance` per token. Rate limits: 5/s UID, 5000/s global on all four.
+
+### Stake / Redeem
+
+```
+POST /v5/alpha/lp/stake
+{"positionId":0,"poolAddress":"0x...","payTokenAmount":"1000","payTokenCode":"CEX_1","rangeUpper":"2000","rangeLower":"1800"}
+```
+
+> `positionId=0` → create new position; non-zero → add to existing. Either `rangeUpper`/`rangeLower` (range order) **or** `priceUpper`/`priceLower` (price-priority order) — not both. Rate: 1/s UID, 2000/s global.
+
+```
+POST /v5/alpha/lp/redeem
+{"positionId":12345,"poolAddress":"0x...","dercRatio":"0.5"}
+```
+
+> `dercRatio`: `0`–`1`. `"0.5"` = redeem 50%, `"1"` = close entire position. Rate: 1/s UID, 2000/s global.
+
+| Endpoint | Path | Method | Required | Optional |
+|----------|------|--------|----------|----------|
+| Stake | `/v5/alpha/lp/stake` | POST | positionId, poolAddress, payTokenAmount, payTokenCode | rangeUpper, rangeLower, priceUpper, priceLower |
+| Redeem | `/v5/alpha/lp/redeem` | POST | positionId, poolAddress, dercRatio | receiveTokenCode |
+| Position List | `/v5/alpha/lp/position-list` | POST | — | — |
+| Order List | `/v5/alpha/lp/order-list` | POST | — | orderType, tokenCode, orderStatus, days, limit, pageIndex, poolAddress |
+
+### Track Status
+
+```
+POST /v5/alpha/lp/position-list  {}
+POST /v5/alpha/lp/order-list  {"orderType":1,"days":7,"limit":20,"pageIndex":1}
+```
+
+> **Position status**: `1` Active · `2` Closed · `3` Processing.
+> **Order status**: `1` Processing · `2` Success · `3` Failed (`failureReason` populated).
+> **Order type filter**: `0` All (default) · `1` Stake · `2` Redeem.
+> `days`: 0–365 (default 90). `limit`: 1–100 (default 20). `pageIndex`: 1-based (default 1).
+> Position-list rate: 3/s UID. Order-list rate: 3/s UID.
+
+### LP Error Codes (180xxx)
+
+| Code | Meaning |
+|------|---------|
+| 180000 | Internal server error |
+| 180001 | Invalid request parameter |
+| 180002 | Token not supported |
+| 180003 | Position not found (redeem) |
+| 180004 | Amount precision exceeds limit |
+| 180006 | Amount below minimum |
+| 180007 | Amount exceeds maximum |
+| 180100 | Service temporarily unavailable |
+| 180104 | Wallet balance insufficient |
+| 180200 | Request conflict |
+
+---
+
 ## Error Codes (180xxx)
 
 | Code | Meaning |

--- a/modules/derivatives.md
+++ b/modules/derivatives.md
@@ -149,6 +149,7 @@ POST /v5/position/trading-stop
 | Endpoint | Path | Method | Required Params | Optional Params | Categories |
 |----------|------|--------|----------------|-----------------|------------|
 | Get Position | `/v5/position/list` | GET | category | symbol, baseCoin, settleCoin, limit, cursor | linear, inverse, option |
+| Get Symbol Leverage | `/v5/position/symbol-info` | GET | category | symbol | linear, inverse |
 | Set Leverage | `/v5/position/set-leverage` | POST | category, symbol, buyLeverage, sellLeverage | — | linear, inverse |
 | Switch Position Mode | `/v5/position/switch-mode` | POST | category, mode | coin, symbol | linear, inverse |
 | Set Trading Stop | `/v5/position/trading-stop` | POST | category, symbol, tpslMode, positionIdx | takeProfit, stopLoss, trailingStop, tpTriggerBy, slTriggerBy, activePrice, tpSize, slSize, tpLimitPrice, slLimitPrice | linear, inverse |
@@ -158,6 +159,12 @@ POST /v5/position/trading-stop
 | Closed PnL | `/v5/position/closed-pnl` | GET | category, symbol | startTime, endTime, limit, cursor | linear, inverse |
 | Closed Options | `/v5/position/get-closed-positions` | GET | category | symbol, limit, cursor | option |
 | Confirm Pending MMR | `/v5/position/confirm-pending-mmr` | POST | category, symbol | — | linear, inverse |
+
+### Get Symbol Leverage (`/v5/position/symbol-info`)
+- Returns `symbol`, `leverage`, `side`, `positionIdx` per position. Hedge mode returns 2 entries per symbol (long + short).
+- `category`: `linear` (USDT perpetual / USDC contract) | `inverse` (Inverse perpetual / futures).
+- Rate limit: 2 req/s (UID). Requires Read or Write key with "Contract-position" permission.
+- **Not supported in Portfolio Margin mode** — returns `retCode=3405112`.
 
 ## Enums
 

--- a/modules/derivatives.md
+++ b/modules/derivatives.md
@@ -161,7 +161,7 @@ POST /v5/position/trading-stop
 | Confirm Pending MMR | `/v5/position/confirm-pending-mmr` | POST | category, symbol | — | linear, inverse |
 
 ### Get Symbol Leverage (`/v5/position/symbol-info`)
-- Returns `symbol`, `leverage`, `side`, `positionIdx` per position. Hedge mode returns 2 entries per symbol (long + short).
+- Returns `symbol`, `leverage`, `side`, `positionIdx` per entry. Per spec field annotation, hedge mode returns 2 entries per symbol (long + short); one-way mode returns 1.
 - `category`: `linear` (USDT perpetual / USDC contract) | `inverse` (Inverse perpetual / futures).
 - Rate limit: 2 req/s (UID). Requires Read or Write key with "Contract-position" permission.
 - **Not supported in Portfolio Margin mode** — returns `retCode=3405112`.

--- a/modules/earn.md
+++ b/modules/earn.md
@@ -423,12 +423,14 @@ GET  /v5/earn/rwa/nav-chart?productId=1001
 | Product List | `/v5/earn/rwa/product` | GET | No | 20/s IP | — | coin |
 | Place Order | `/v5/earn/rwa/place-order` | POST | Yes | 5/s UID | productId, orderType, coin, orderLinkId | stakeAmount (Stake), redeemShares (Redeem), accountType |
 | Position | `/v5/earn/rwa/position` | GET | Yes | 10/s UID | — | — |
-| Order List | `/v5/earn/rwa/order` | GET | Yes | 10/s UID | — | orderId, orderLinkId, orderType, productId, startTime, endTime, limit, cursor |
+| Order List | `/v5/earn/rwa/order` | GET | Yes | 10/s UID | — | orderId, orderLinkId, orderType, productId, startTime, endTime, limit (1–50, default 20), cursor |
 | NAV Chart | `/v5/earn/rwa/nav-chart` | GET | No | 20/s IP | productId | startTime, endTime |
 
 **Enums**: orderType: `Stake`|`Redeem` · accountType: `FUND`(default)|`UNIFIED` · order status: `Processing`|`Success`|`Failed` · savingType: `Flexible`|`Fixed`
 
-> **Stake**: requires `stakeAmount`; deducts settlement coin from `accountType`, allocates shares at next NAV. **Redeem**: requires `redeemShares`; locks shares, refunds settlement coin to `accountType` after T+N settlement. `orderLinkId` reuse returns error `180025`. Order list: `startTime` defaults 7d ago, earliest 180d ago. NAV chart: time span ≤ 180 days; `startTime` defaults `endTime - 7d`, `endTime` defaults now.
+> **⚠️ Timestamp unit (RWA-specific)**: `startTime` / `endTime` on `/v5/earn/rwa/order` and `/v5/earn/rwa/nav-chart` are **Unix seconds**, NOT milliseconds. This differs from Bybit V5 default (most other endpoints use ms). Sending ms will be rejected or return empty.
+>
+> **Stake**: requires `stakeAmount`; deducts settlement coin from `accountType`, allocates shares at next NAV. **Redeem**: requires `redeemShares`; locks shares, refunds settlement coin to `accountType` after T+N settlement. `orderLinkId` reuse returns error `180025`. Order list: `startTime` defaults 7d ago, earliest 180d ago, `limit` max **50** (not 100). NAV chart: time span ≤ 180 days; `startTime` defaults `endTime - 7d`, `endTime` defaults now.
 
 **RWA Error codes (180xxx)**: `180007` Product offline / out of subscription window · `180008` Product does not exist · `180012` Purchase share out of [min,max] range · `180013` Stake over individual maximum · `180014` Redeem share invalid · `180015` Sold out · `180016` Balance not enough · `180019` orderLinkId required · `180020` Position not found · `180022` KYC level not reached · `180025` Duplicate orderLinkId · `180029` Redeem not allowed.
 

--- a/modules/earn.md
+++ b/modules/earn.md
@@ -9,8 +9,9 @@
 3. [Advance Earn](#scenario-advance-earn) — Dual Assets / Smart Leverage / DoubleWin / Discount Buy
 4. [Liquidity Mining](#scenario-liquidity-mining) — Pool liquidity provision
 5. [BYUSDT Token](#scenario-byusdt-token) — Mint / Redeem earn token
-6. [Hold-to-Earn](#scenario-hold-to-earn) — Airdrop yield by holding coins
-7. [PWM (Private Wealth Management)](#scenario-pwm) — Institutional fund management & user investment plans
+6. [RWA Earn](#scenario-rwa-earn) — Tokenized real-world asset stake/redeem (BlackRock IGBF etc.)
+7. [Hold-to-Earn](#scenario-hold-to-earn) — Airdrop yield by holding coins
+8. [PWM (Private Wealth Management)](#scenario-pwm) — Institutional fund management & user investment plans
 
 ---
 
@@ -56,13 +57,16 @@ GET  /v5/earn/hourly-yield?category=FlexibleSaving
 | Endpoint | Path | Method | Required | Optional |
 |----------|------|--------|----------|----------|
 | Product | `/v5/earn/product` | GET | category | coin |
-| Place Order | `/v5/earn/place-order` | POST | category, orderType, accountType, coin, amount, productId, orderLinkId | redeemPositionId, toAccountType |
+| Place Order | `/v5/earn/place-order` | POST | category, orderType, accountType, coin, amount, productId, orderLinkId | redeemPositionId, toAccountType, interestCard |
 | Order | `/v5/earn/order` | GET | category | orderId, orderLinkId, productId, startTime, endTime, limit, cursor |
 | Position | `/v5/earn/position` | GET | category | productId, coin |
 | Yield | `/v5/earn/yield` | GET | category | productId, startTime, endTime, limit, cursor |
 | Hourly Yield | `/v5/earn/hourly-yield` | GET | category | productId, startTime, endTime, limit, cursor |
+| List Coupons | `/v5/earn/coupons` | GET | category | — |
 
 **Enums**: orderType: `Stake`|`Redeem` · category: `FlexibleSaving`|`OnChain`
+
+> **Coupons** (`/v5/earn/coupons`, category: `FlexibleSaving`|`DualAssets`): returns user's `interestCards` (interest-rate coupons) and `awardCards` (Dual Assets reward cards / trial funds). Card status: `InUse`|`NotUse`|`Expired`|`AlreadyUsed`. To apply when staking, pass `interestCard:{awardId, specCode}` to `/v5/earn/place-order` (FlexibleSaving Stake) or `/v5/earn/advance/place-order` (DualAssets). Rate limit: 10 req/s (UID).
 
 ---
 
@@ -389,6 +393,44 @@ GET /v5/earn/token/history-apr?coin=BYUSDT&range=2
 | Yield History | `/v5/earn/token/yield` | GET | Yes | coin | startTime, endTime, limit, cursor |
 | Hourly Yield | `/v5/earn/token/hourly-yield` | GET | Yes | coin | startTime, endTime, limit, cursor |
 | APR History | `/v5/earn/token/history-apr` | GET | No | coin, range | — |
+
+---
+
+## Scenario: RWA Earn
+
+User might say: "RWA earn", "tokenized real-world asset", "BlackRock IGBF", "stake RWA", "redeem RWA shares", "NAV chart"
+
+> Bybit V5 RWA (Real World Asset) Earn — Stake (subscribe shares) and Redeem (redeem shares) tokenized real-world asset products. Each product holds shares of an underlying asset (e.g. IGBF) priced by NAV. Settlement is T+N, NAV-based valuation.
+
+**⚠️ Mandatory Stake/Redeem flow**
+
+> 1. `GET /v5/earn/rwa/product` → find `productId`, check `nav`, `minStakeAmount`/`maxStakeAmount`, `userQuota`, `redeemFeeRate`
+> 2. **Confirm with user** before placing: product, settlement coin, amount or shares, current NAV, expected settlement time
+> 3. `POST /v5/earn/rwa/place-order` with unique `orderLinkId` (max 36 chars, charset `[a-zA-Z0-9-_]`, required)
+> 4. Track via `GET /v5/earn/rwa/order` (poll until `status=Success` or `Failed`)
+
+```
+GET  /v5/earn/rwa/product?coin=USDC
+POST /v5/earn/rwa/place-order  {"productId":1001,"orderType":"Stake","coin":"USDC","stakeAmount":"100","accountType":"FUND","orderLinkId":"my-stake-001"}
+POST /v5/earn/rwa/place-order  {"productId":1001,"orderType":"Redeem","coin":"USDC","redeemShares":"50","accountType":"FUND","orderLinkId":"my-redeem-001"}
+GET  /v5/earn/rwa/position
+GET  /v5/earn/rwa/order?orderLinkId=my-stake-001
+GET  /v5/earn/rwa/nav-chart?productId=1001
+```
+
+| Endpoint | Path | Method | Auth | Rate | Required | Optional |
+|----------|------|--------|------|------|----------|----------|
+| Product List | `/v5/earn/rwa/product` | GET | No | 20/s IP | — | coin |
+| Place Order | `/v5/earn/rwa/place-order` | POST | Yes | 5/s UID | productId, orderType, coin, orderLinkId | stakeAmount (Stake), redeemShares (Redeem), accountType |
+| Position | `/v5/earn/rwa/position` | GET | Yes | 10/s UID | — | — |
+| Order List | `/v5/earn/rwa/order` | GET | Yes | 10/s UID | — | orderId, orderLinkId, orderType, productId, startTime, endTime, limit, cursor |
+| NAV Chart | `/v5/earn/rwa/nav-chart` | GET | No | 20/s IP | productId | startTime, endTime |
+
+**Enums**: orderType: `Stake`|`Redeem` · accountType: `FUND`(default)|`UNIFIED` · order status: `Processing`|`Success`|`Failed` · savingType: `Flexible`|`Fixed`
+
+> **Stake**: requires `stakeAmount`; deducts settlement coin from `accountType`, allocates shares at next NAV. **Redeem**: requires `redeemShares`; locks shares, refunds settlement coin to `accountType` after T+N settlement. `orderLinkId` reuse returns error `180025`. Order list: `startTime` defaults 7d ago, earliest 180d ago. NAV chart: time span ≤ 180 days; `startTime` defaults `endTime - 7d`, `endTime` defaults now.
+
+**RWA Error codes (180xxx)**: `180007` Product offline / out of subscription window · `180008` Product does not exist · `180012` Purchase share out of [min,max] range · `180013` Stake over individual maximum · `180014` Redeem share invalid · `180015` Sold out · `180016` Balance not enough · `180019` orderLinkId required · `180020` Position not found · `180022` KYC level not reached · `180025` Duplicate orderLinkId · `180029` Redeem not allowed.
 
 ---
 


### PR DESCRIPTION
## Summary
Spec sync from openapi-spec 1639d93..90280fc + version bump to v1.4.3.

### 新增接口
- **earn.md** — RWA Earn 5 个接口（`product`/`place-order`/`position`/`order`/`nav-chart`）+ `/v5/earn/coupons`
- **alpha-trade.md** — Alpha LP / Farm 8 个接口（pool/pay-token/stake/redeem/position/order）
- **derivatives.md** — `/v5/position/symbol-info`

### 字段变更
- earn `/v5/earn/place-order`: optional `interestCard` 参数
- account `/v5/account/set-margin-mode`: 新增错误码 `3200425`

## Test plan
- [ ] Module structure verified against spec
- [ ] Manifest hashes match GitLab + ai-skill-manifest